### PR TITLE
feat(tracking): add article visit tracker to store user visit history

### DIFF
--- a/app/articles/[slug]/page.tsx
+++ b/app/articles/[slug]/page.tsx
@@ -5,6 +5,7 @@ import React from "react";
 import TopicsList from "@/components/TopicsList";
 import TableOfContents from "@/components/TableOfContents";
 import RelatedPosts from "@/components/RelatedPosts";
+import ArticleVisitTracker from "@/components/ArticleVisitTracker";
 import { getRelatedPosts, getAllPosts } from "@/lib/rss";
 import { formatReadingLabel } from "@/utils/calculateReadingTime";
 import "./article.css";
@@ -39,11 +40,13 @@ export default async function ArticlePage({ params }: PageProps) {
   let topics: string[] = [];
   let related: Awaited<ReturnType<typeof getRelatedPosts>> = [];
   let readingMinutes: number | undefined = undefined;
+  let title = slug;
 
   try {
     const mod = await import(`@/content/${slug}.mdx`);
     MDXComponent = mod.default;
     topics = mod.metadata?.topics ?? [];
+    title = mod.metadata?.title ?? slug;
     const all = await getAllPosts();
     const me = all.find((p) => p.slug === slug);
     readingMinutes = me?.readingMinutes;
@@ -85,6 +88,7 @@ export default async function ArticlePage({ params }: PageProps) {
       </article>
       <TableOfContents />
       <FavButton articleSlug={slug} />
+      <ArticleVisitTracker slug={slug} title={title} topics={topics} />
       <BackToTopButton />
     </>
   );

--- a/components/ArticleVisitTracker.tsx
+++ b/components/ArticleVisitTracker.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useEffect } from "react";
+
+const VISIT_STORAGE_KEY = "devverse:article-visit-history";
+const MAX_STORED_VISITS = 50;
+
+interface ArticleVisitTrackerProps {
+  slug: string;
+  title: string;
+  topics: string[];
+}
+
+export default function ArticleVisitTracker({
+  slug,
+  title,
+  topics,
+}: ArticleVisitTrackerProps) {
+  useEffect(() => {
+    if (!slug) return;
+
+    try {
+      const raw = window.localStorage.getItem(VISIT_STORAGE_KEY);
+      const parsed = raw ? JSON.parse(raw) : [];
+      const list = Array.isArray(parsed) ? parsed : [];
+
+      const next = [
+        {
+          slug,
+          title,
+          topics,
+          lastViewed: Date.now(),
+        },
+        ...list.filter((entry: any) => entry?.slug !== slug),
+      ].slice(0, MAX_STORED_VISITS);
+
+      window.localStorage.setItem(VISIT_STORAGE_KEY, JSON.stringify(next));
+    } catch {
+      // Ignore localStorage errors (private mode, blocked storage, etc.).
+    }
+  }, [slug, title, topics]);
+
+  return null;
+}

--- a/components/ArticlesList.tsx
+++ b/components/ArticlesList.tsx
@@ -3,7 +3,47 @@
 import React, { useState, useEffect, useMemo } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import InteractiveCard from "./InteractiveCard";
-import { FaTags, FaTimes, FaSearch, FaInfoCircle } from "react-icons/fa";
+import {
+  FaTags,
+  FaTimes,
+  FaSearch,
+  FaInfoCircle,
+  FaChevronLeft,
+  FaChevronRight,
+} from "react-icons/fa";
+
+const VISIT_STORAGE_KEY = "devverse:article-visit-history";
+
+const TITLE_STOP_WORDS = new Set([
+  "about",
+  "after",
+  "before",
+  "between",
+  "from",
+  "into",
+  "over",
+  "that",
+  "the",
+  "this",
+  "with",
+  "your",
+  "what",
+  "when",
+  "where",
+  "why",
+  "how",
+  "and",
+  "for",
+  "are",
+  "you",
+  "our",
+]);
+
+const tokenizeText = (text: string) =>
+  text
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((word) => word.length > 3 && !TITLE_STOP_WORDS.has(word));
 
 interface Article {
   slug: string;
@@ -17,11 +57,20 @@ interface Article {
 interface ArticlesListProps {
   articles: Article[];
   showSearch?: boolean;
+  showCarousel?: boolean;
+}
+
+interface ArticleVisitRecord {
+  slug: string;
+  title?: string;
+  topics?: string[];
+  lastViewed?: number;
 }
 
 export default function ArticlesList({
   articles,
   showSearch = true,
+  showCarousel = true,
 }: ArticlesListProps) {
   // Collect all distinct topics across the articles.
   const allTopicsSet = new Set<string>();
@@ -35,10 +84,11 @@ export default function ArticlesList({
 
   const [searchTerm, setSearchTerm] = useState("");
   const [isSearchFocused, setIsSearchFocused] = useState(false);
+  const [visitHistory, setVisitHistory] = useState<ArticleVisitRecord[]>([]);
 
   // State for the currently selected topics and how many articles to show.
   const [selectedTopics, setSelectedTopics] = useState<string[]>([]);
-  const [visibleCount, setVisibleCount] = useState(10); // Show 10 articles initially
+  const [visibleCount, setVisibleCount] = useState(12);
   // State for how many topics are visible.
   const [visibleTopicsCount, setVisibleTopicsCount] = useState(10);
 
@@ -66,7 +116,7 @@ export default function ArticlesList({
 
   useEffect(() => {
     if (!showSearch) return;
-    setVisibleCount(10);
+    setVisibleCount(12);
   }, [searchTerm, showSearch]);
 
   const normalizedSearch = searchTerm.trim().toLowerCase();
@@ -95,7 +145,10 @@ export default function ArticlesList({
   }, [articles, normalizedSearch, selectedTopics]);
 
   // Slice the filtered list to show only the visible portion.
-  const displayedArticles = filteredArticles.slice(0, visibleCount);
+  const displayedArticles = useMemo(
+    () => filteredArticles.slice(0, visibleCount),
+    [filteredArticles, visibleCount],
+  );
   // Only show a subset of topics.
   const displayedTopics = allTopics.slice(0, visibleTopicsCount);
 
@@ -103,9 +156,9 @@ export default function ArticlesList({
   const totalFiltered = filteredArticles.length;
   const totalDisplayed = displayedArticles.length;
 
-  const allCardElements = useMemo(
+  const displayedCardElements = useMemo(
     () =>
-      filteredArticles.map((article, i) => (
+      displayedArticles.map((article, i) => (
         <div
           key={article.slug}
           className="fade-in-card"
@@ -119,10 +172,8 @@ export default function ArticlesList({
           />
         </div>
       )),
-    [filteredArticles],
+    [displayedArticles],
   );
-
-  const displayedCardElements = allCardElements.slice(0, visibleCount);
 
   // Toggle topic selection
   const updateURL = (topics: string[]) => {
@@ -144,7 +195,7 @@ export default function ArticlesList({
   };
 
   const toggleTopic = (topic: string) => {
-    setVisibleCount(10);
+    setVisibleCount(12);
     setSelectedTopics((prev) => {
       const next = prev.includes(topic)
         ? prev.filter((t) => t !== topic)
@@ -156,7 +207,7 @@ export default function ArticlesList({
 
   // Clear all selections.
   const clearSelection = () => {
-    setVisibleCount(10); // Reset visible articles when clearing selection
+    setVisibleCount(12);
     setSelectedTopics([]);
     updateURL([]);
   };
@@ -176,6 +227,182 @@ export default function ArticlesList({
       setInitialized(true);
     }
   }, [searchParams, initialized]);
+
+  useEffect(() => {
+    if (!showCarousel) return;
+
+    const loadHistory = () => {
+      try {
+        const raw = window.localStorage.getItem(VISIT_STORAGE_KEY);
+        const parsed = raw ? JSON.parse(raw) : [];
+        if (!Array.isArray(parsed)) {
+          setVisitHistory([]);
+          return;
+        }
+        const cleaned = parsed
+          .filter((entry) => entry && typeof entry.slug === "string")
+          .map((entry) => ({
+            slug: entry.slug,
+            title: typeof entry.title === "string" ? entry.title : "",
+            topics: Array.isArray(entry.topics)
+              ? entry.topics.filter(
+                  (topic: unknown) => typeof topic === "string",
+                )
+              : [],
+            lastViewed:
+              typeof entry.lastViewed === "number" ? entry.lastViewed : 0,
+          }));
+        setVisitHistory(cleaned);
+      } catch {
+        setVisitHistory([]);
+      }
+    };
+
+    loadHistory();
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === VISIT_STORAGE_KEY) {
+        loadHistory();
+      }
+    };
+
+    window.addEventListener("storage", handleStorage);
+    return () => window.removeEventListener("storage", handleStorage);
+  }, [showCarousel]);
+
+  const [carouselPage, setCarouselPage] = useState(0);
+  const [carouselPageSize, setCarouselPageSize] = useState(3);
+
+  useEffect(() => {
+    if (!showCarousel) return;
+
+    const updatePageSize = () => {
+      const width = window.innerWidth;
+      const nextSize = width < 720 ? 1 : width < 1080 ? 2 : 3;
+      setCarouselPageSize(nextSize);
+    };
+
+    updatePageSize();
+    window.addEventListener("resize", updatePageSize);
+
+    return () => window.removeEventListener("resize", updatePageSize);
+  }, [showCarousel]);
+
+  useEffect(() => {
+    if (!showCarousel) return;
+    setCarouselPage(0);
+  }, [normalizedSearch, selectedTopics, showCarousel, visitHistory]);
+
+  const hasVisitHistory = visitHistory.length > 0;
+  const targetCarouselCount = Math.max(12, visibleCount);
+
+  const recommendedArticles = useMemo(() => {
+    if (!hasVisitHistory) return [];
+
+    const visitedSlugs = new Set(visitHistory.map((item) => item.slug));
+    const visitedTopics = new Set(
+      visitHistory.flatMap((item) => item.topics ?? []),
+    );
+    const visitedTokens = new Set(
+      visitHistory.flatMap((item) => tokenizeText(item.title ?? "")),
+    );
+
+    const scored = articles.map((article) => {
+      const topicScore = article.topics.filter((topic) =>
+        visitedTopics.has(topic),
+      ).length;
+      const titleScore = tokenizeText(article.title).filter((token) =>
+        visitedTokens.has(token),
+      ).length;
+      const descriptionScore = tokenizeText(
+        `${article.description ?? ""} ${article.excerpt ?? ""}`,
+      ).filter((token) => visitedTokens.has(token)).length;
+
+      return {
+        article,
+        score: topicScore * 3 + titleScore * 2 + descriptionScore,
+      };
+    });
+
+    scored.sort((a, b) => {
+      if (b.score !== a.score) return b.score - a.score;
+      return a.article.title.localeCompare(b.article.title);
+    });
+
+    const result: Article[] = [];
+    const seen = new Set<string>();
+    const pushArticle = (item: { article: Article }) => {
+      if (result.length >= targetCarouselCount) return;
+      if (seen.has(item.article.slug)) return;
+      result.push(item.article);
+      seen.add(item.article.slug);
+    };
+
+    const unvisited = scored.filter(
+      (item) => !visitedSlugs.has(item.article.slug),
+    );
+    const visited = scored.filter((item) =>
+      visitedSlugs.has(item.article.slug),
+    );
+
+    unvisited.filter((item) => item.score > 0).forEach(pushArticle);
+    unvisited.filter((item) => item.score <= 0).forEach(pushArticle);
+    visited.forEach(pushArticle);
+
+    return result;
+  }, [articles, hasVisitHistory, targetCarouselCount, visitHistory]);
+
+  const carouselArticles = hasVisitHistory
+    ? recommendedArticles
+    : displayedArticles.slice(0, targetCarouselCount);
+
+  const carouselPages = useMemo(() => {
+    if (!showCarousel) return [];
+    const pages: Article[][] = [];
+    for (let i = 0; i < carouselArticles.length; i += carouselPageSize) {
+      pages.push(carouselArticles.slice(i, i + carouselPageSize));
+    }
+    return pages;
+  }, [carouselArticles, carouselPageSize, showCarousel]);
+
+  const totalCarouselPages = carouselPages.length;
+
+  useEffect(() => {
+    if (!showCarousel) return;
+    if (totalCarouselPages === 0) {
+      setCarouselPage(0);
+      return;
+    }
+    if (carouselPage > totalCarouselPages - 1) {
+      setCarouselPage(totalCarouselPages - 1);
+    }
+  }, [carouselPage, totalCarouselPages, showCarousel]);
+
+  useEffect(() => {
+    if (!showCarousel || totalCarouselPages < 2) return;
+
+    const prefersReducedMotion =
+      typeof window !== "undefined" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+    if (prefersReducedMotion) return;
+
+    const intervalId = window.setInterval(() => {
+      setCarouselPage((prev) =>
+        prev >= totalCarouselPages - 1 ? 0 : prev + 1,
+      );
+    }, 3000);
+
+    return () => window.clearInterval(intervalId);
+  }, [showCarousel, totalCarouselPages]);
+
+  const carouselKicker = hasVisitHistory ? "Recommended" : "Quick browse";
+  const carouselTitle = hasVisitHistory
+    ? "Recommended articles for you."
+    : "Flip through the article deck.";
+  const carouselSubtitle = hasVisitHistory
+    ? "Tuned using what you read most: topics, titles, and themes."
+    : "A quick pass before diving into the full list.";
 
   return (
     <div>
@@ -257,6 +484,92 @@ export default function ArticlesList({
         </div>
       </div>
 
+      {showCarousel && totalCarouselPages > 0 && (
+        <section className="articles-carousel">
+          <div className="carousel-header">
+            <div>
+              <p className="carousel-kicker">{carouselKicker}</p>
+              <h2 className="carousel-title">{carouselTitle}</h2>
+              <p className="carousel-subtitle">{carouselSubtitle}</p>
+            </div>
+            <div className="carousel-controls">
+              <button
+                type="button"
+                className="carousel-btn"
+                onClick={() => setCarouselPage((prev) => Math.max(prev - 1, 0))}
+                aria-label="Previous articles"
+                disabled={carouselPage === 0}
+              >
+                <FaChevronLeft aria-hidden="true" />
+              </button>
+              <button
+                type="button"
+                className="carousel-btn"
+                onClick={() =>
+                  setCarouselPage((prev) =>
+                    Math.min(prev + 1, totalCarouselPages - 1),
+                  )
+                }
+                aria-label="Next articles"
+                disabled={carouselPage === totalCarouselPages - 1}
+              >
+                <FaChevronRight aria-hidden="true" />
+              </button>
+            </div>
+          </div>
+          <div className="carousel-viewport">
+            <div
+              className="carousel-track"
+              style={{
+                transform: `translateX(-${carouselPage * 100}%)`,
+              }}
+            >
+              {carouselPages.map((page, pageIndex) => (
+                <div
+                  key={`carousel-page-${pageIndex}`}
+                  className="carousel-page"
+                  style={
+                    {
+                      "--carousel-cols": carouselPageSize,
+                    } as React.CSSProperties
+                  }
+                >
+                  {page.map((article) => (
+                    <div key={article.slug} className="carousel-card">
+                      <InteractiveCard
+                        slug={article.slug}
+                        title={article.title}
+                        description={article.description || article.excerpt}
+                        readingTimeMinutes={article.readingMinutes}
+                      />
+                    </div>
+                  ))}
+                </div>
+              ))}
+            </div>
+          </div>
+          <div className="carousel-pagination">
+            {carouselPages.map((_, index) => (
+              <button
+                key={`carousel-dot-${index}`}
+                type="button"
+                className={`carousel-dot ${index === carouselPage ? "active" : ""}`}
+                onClick={() => setCarouselPage(index)}
+                aria-label={`Go to carousel page ${index + 1}`}
+              />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {showCarousel && (
+        <div className="all-articles-heading">
+          <div className="all-articles-divider" aria-hidden="true" />
+          <h2 className="all-articles-title">All Articles</h2>
+          <div className="all-articles-divider" aria-hidden="true" />
+        </div>
+      )}
+
       {/* Articles Grid */}
       <div className="article-grid">{displayedCardElements}</div>
 
@@ -265,7 +578,7 @@ export default function ArticlesList({
         <div style={{ textAlign: "center", marginTop: "2rem" }}>
           <button
             className="load-more-btn"
-            onClick={() => setVisibleCount((prev) => prev + 10)}
+            onClick={() => setVisibleCount((prev) => prev + 12)}
           >
             Load More Articles
             <span className="arrow">↓</span>
@@ -594,6 +907,190 @@ export default function ArticlesList({
           gap: 2rem;
         }
 
+        .all-articles-heading {
+          margin: 2.8rem 0 2.2rem;
+          display: grid;
+          gap: 0.6rem;
+          place-items: center;
+          text-align: center;
+        }
+
+        .all-articles-divider {
+          height: 1px;
+          width: min(360px, 70%);
+          background: linear-gradient(
+            90deg,
+            transparent,
+            rgba(0, 112, 243, 0.4),
+            transparent
+          );
+        }
+
+        .all-articles-title {
+          margin: 0;
+          font-size: clamp(1.6rem, 2.4vw, 2rem);
+          letter-spacing: 0.08em;
+          text-transform: uppercase;
+          font-weight: 700;
+          color: var(--text-color);
+        }
+
+        .articles-carousel {
+          margin: 2.5rem 0 3rem;
+          padding: 1.75rem;
+          border-radius: 22px;
+          border: 1px solid var(--border-color);
+          background:
+            radial-gradient(
+              circle at top left,
+              rgba(15, 118, 110, 0.18),
+              transparent 55%
+            ),
+            linear-gradient(135deg, rgba(0, 112, 243, 0.08), rgba(0, 0, 0, 0));
+          position: relative;
+        }
+
+        .carousel-header {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 1rem;
+          justify-content: space-between;
+          align-items: center;
+          margin-bottom: 1.5rem;
+        }
+
+        .carousel-kicker {
+          text-transform: uppercase;
+          letter-spacing: 0.2em;
+          font-size: 0.7rem;
+          font-weight: 700;
+          color: var(--link-color);
+          margin: 0;
+        }
+
+        .carousel-title {
+          margin: 0.5rem 0 0.35rem;
+          font-size: 1.55rem;
+          color: var(--text-color);
+        }
+
+        .carousel-subtitle {
+          margin: 0;
+          color: var(--text-color);
+          opacity: 0.75;
+          max-width: 520px;
+          line-height: 1.6;
+        }
+
+        .carousel-controls {
+          display: inline-flex;
+          gap: 0.6rem;
+          align-items: center;
+        }
+
+        .carousel-btn {
+          width: 42px;
+          height: 42px;
+          border-radius: 50%;
+          border: 1px solid var(--border-color);
+          background: var(--container-background);
+          color: var(--text-color);
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          cursor: pointer;
+          transition:
+            transform 0.2s ease,
+            box-shadow 0.2s ease,
+            border-color 0.2s ease;
+        }
+
+        .carousel-btn:hover:not(:disabled) {
+          transform: translateY(-2px);
+          border-color: var(--link-color);
+          box-shadow: 0 14px 26px rgba(15, 23, 42, 0.15);
+        }
+
+        .carousel-btn:disabled {
+          opacity: 0.4;
+          cursor: not-allowed;
+          box-shadow: none;
+        }
+
+        .carousel-viewport {
+          overflow: hidden;
+          width: 100%;
+          padding: 0.6rem 0.3rem 1rem;
+          box-sizing: border-box;
+        }
+
+        .carousel-track {
+          display: flex;
+          transition: transform 0.45s ease;
+        }
+
+        .carousel-page {
+          min-width: 100%;
+          display: grid;
+          grid-template-columns: repeat(var(--carousel-cols), minmax(0, 1fr));
+          gap: 1.5rem;
+          padding: 0.2rem 0.1rem;
+          box-sizing: border-box;
+        }
+
+        .carousel-card {
+          height: 100%;
+          padding: 0.2rem;
+          box-sizing: border-box;
+        }
+
+        .articles-carousel :global(.interactive-card-title) {
+          display: -webkit-box;
+          -webkit-line-clamp: 2;
+          -webkit-box-orient: vertical;
+          overflow: hidden;
+        }
+
+        .articles-carousel :global(.interactive-card-description) {
+          display: -webkit-box;
+          -webkit-line-clamp: 3;
+          -webkit-box-orient: vertical;
+          overflow: hidden;
+        }
+
+        .articles-carousel :global(.interactive-card) {
+          box-shadow: none;
+        }
+
+        .articles-carousel :global(.interactive-card:hover) {
+          box-shadow: none;
+        }
+
+        .carousel-pagination {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          gap: 0.5rem;
+          margin-top: 1.3rem;
+        }
+
+        .carousel-dot {
+          width: 10px;
+          height: 10px;
+          border-radius: 999px;
+          border: none;
+          background: rgba(0, 112, 243, 0.2);
+          cursor: pointer;
+          transition:
+            width 0.2s ease,
+            background-color 0.2s ease;
+        }
+
+        .carousel-dot.active {
+          width: 26px;
+          background: var(--link-color);
+        }
+
         .fade-in-card {
           opacity: 0;
           animation: fadeIn 0.5s ease forwards;
@@ -612,6 +1109,19 @@ export default function ArticlesList({
 
           .search-filter-title {
             font-size: 1.4rem;
+          }
+
+          .articles-carousel {
+            padding: 1.4rem;
+          }
+
+          .carousel-title {
+            font-size: 1.35rem;
+          }
+
+          .carousel-controls {
+            width: 100%;
+            justify-content: flex-start;
           }
         }
       `}</style>

--- a/components/FavoritesList.tsx
+++ b/components/FavoritesList.tsx
@@ -251,7 +251,11 @@ export default function FavoritesList({ articles }: FavoritesListProps) {
         <p className="no-favorites-message">You have no favorite articles.</p>
       ) : filteredFavorites.length > 0 ? (
         <div className="articles-list-wrapper">
-          <ArticlesList articles={filteredFavorites} showSearch={false} />
+          <ArticlesList
+            articles={filteredFavorites}
+            showSearch={false}
+            showCarousel={false}
+          />
         </div>
       ) : (
         <p className="no-favorites-message">


### PR DESCRIPTION
This pull request introduces a new feature to track article visits in local storage, and includes a minor UI adjustment to the favorites list. The most significant change is the addition of the `ArticleVisitTracker` component, which records article views for up to 50 articles in the user's browser. This lays the groundwork for features like recently viewed articles or personalized recommendations.

**Article visit tracking:**

* Added new `ArticleVisitTracker` component (`components/ArticleVisitTracker.tsx`) that records article visits (slug, title, topics, and timestamp) in `localStorage`, keeping a maximum of 50 entries.
* Integrated `ArticleVisitTracker` into the article page (`app/articles/[slug]/page.tsx`), passing the current article's slug, title, and topics. ([app/articles/[slug]/page.tsxR8](diffhunk://#diff-f3bf73d97ac06ae1b7baf9db7bac83040906a6f7d9f6f98e7d9c89c809370eccR8), [app/articles/[slug]/page.tsxR43-R49](diffhunk://#diff-f3bf73d97ac06ae1b7baf9db7bac83040906a6f7d9f6f98e7d9c89c809370eccR43-R49), [app/articles/[slug]/page.tsxR91](diffhunk://#diff-f3bf73d97ac06ae1b7baf9db7bac83040906a6f7d9f6f98e7d9c89c809370eccR91))

**UI adjustment:**

* Updated `FavoritesList` to explicitly disable the carousel in the `ArticlesList` component when displaying favorite articles.