### PR TITLE
feat(articles): enhance carousel navigation with improved interaction handling

### DIFF
--- a/components/ArticlesList.tsx
+++ b/components/ArticlesList.tsx
@@ -272,6 +272,7 @@ export default function ArticlesList({
 
   const [carouselPage, setCarouselPage] = useState(0);
   const [carouselPageSize, setCarouselPageSize] = useState(3);
+  const [carouselInteractionKey, setCarouselInteractionKey] = useState(0);
 
   useEffect(() => {
     if (!showCarousel) return;
@@ -394,7 +395,7 @@ export default function ArticlesList({
     }, 3000);
 
     return () => window.clearInterval(intervalId);
-  }, [showCarousel, totalCarouselPages]);
+  }, [showCarousel, totalCarouselPages, carouselInteractionKey]);
 
   const carouselKicker = hasVisitHistory ? "Recommended" : "Quick browse";
   const carouselTitle = hasVisitHistory
@@ -496,22 +497,36 @@ export default function ArticlesList({
               <button
                 type="button"
                 className="carousel-btn"
-                onClick={() => setCarouselPage((prev) => Math.max(prev - 1, 0))}
+                onClick={() => {
+                  setCarouselPage((prev) =>
+                    totalCarouselPages === 0
+                      ? 0
+                      : prev === 0
+                        ? totalCarouselPages - 1
+                        : prev - 1,
+                  );
+                  setCarouselInteractionKey((prev) => prev + 1);
+                }}
                 aria-label="Previous articles"
-                disabled={carouselPage === 0}
+                disabled={totalCarouselPages === 0}
               >
                 <FaChevronLeft aria-hidden="true" />
               </button>
               <button
                 type="button"
                 className="carousel-btn"
-                onClick={() =>
+                onClick={() => {
                   setCarouselPage((prev) =>
-                    Math.min(prev + 1, totalCarouselPages - 1),
-                  )
-                }
+                    totalCarouselPages === 0
+                      ? 0
+                      : prev >= totalCarouselPages - 1
+                        ? 0
+                        : prev + 1,
+                  );
+                  setCarouselInteractionKey((prev) => prev + 1);
+                }}
                 aria-label="Next articles"
-                disabled={carouselPage === totalCarouselPages - 1}
+                disabled={totalCarouselPages === 0}
               >
                 <FaChevronRight aria-hidden="true" />
               </button>
@@ -554,7 +569,10 @@ export default function ArticlesList({
                 key={`carousel-dot-${index}`}
                 type="button"
                 className={`carousel-dot ${index === carouselPage ? "active" : ""}`}
-                onClick={() => setCarouselPage(index)}
+                onClick={() => {
+                  setCarouselPage(index);
+                  setCarouselInteractionKey((prev) => prev + 1);
+                }}
                 aria-label={`Go to carousel page ${index + 1}`}
               />
             ))}
@@ -1030,7 +1048,8 @@ export default function ArticlesList({
         }
 
         .carousel-page {
-          min-width: 100%;
+          flex: 0 0 100%;
+          width: 100%;
           display: grid;
           grid-template-columns: repeat(var(--carousel-cols), minmax(0, 1fr));
           gap: 1.5rem;


### PR DESCRIPTION
This pull request improves the carousel functionality in the `ArticlesList` component by making carousel navigation wrap around, tracking user interactions to reset the auto-scroll timer, and updating carousel button and dot behavior. These changes enhance the user experience by allowing seamless navigation and preventing unwanted auto-scroll after manual interaction.

**Carousel navigation and interaction improvements:**

* Carousel navigation buttons now wrap around: clicking "previous" on the first page goes to the last page, and clicking "next" on the last page goes to the first page. Also, navigation is disabled if there are no pages.
* Clicking carousel navigation buttons or dots increments a new `carouselInteractionKey` state, which is added as a dependency to the auto-scroll interval effect. This ensures the auto-scroll timer resets after any user interaction, preventing unwanted auto-scroll immediately after a manual navigation. [[1]](diffhunk://#diff-c0018641e35f0fa0c9e0f1da3763181c58e53836c6e6cedbaa5461ef3752a08cR275) [[2]](diffhunk://#diff-c0018641e35f0fa0c9e0f1da3763181c58e53836c6e6cedbaa5461ef3752a08cL397-R398) [[3]](diffhunk://#diff-c0018641e35f0fa0c9e0f1da3763181c58e53836c6e6cedbaa5461ef3752a08cL499-R529) [[4]](diffhunk://#diff-c0018641e35f0fa0c9e0f1da3763181c58e53836c6e6cedbaa5461ef3752a08cL557-R575)

**Carousel layout update:**

* The `.carousel-page` CSS was updated to use `flex: 0 0 100%` and `width: 100%` for improved layout consistency.