### PR TITLE
fix(translate): improve user guidance for translation availability messages

### DIFF
--- a/components/TranslateMenuProvider.tsx
+++ b/components/TranslateMenuProvider.tsx
@@ -414,8 +414,9 @@ export function TranslateMenuProvider({ children }: { children: ReactNode }) {
             )}
             {!translateReady && (
               <div className="translate-hint">
-                If you see &quot;not available,&quot; try reloading this page.
-                If nothing appears yet, give it a moment to load.
+                If you see &quot;Translation unavailable&quot; or similar, try
+                reloading this page. If nothing appears yet, please give it a
+                moment to load or reload the page.
               </div>
             )}
             <div


### PR DESCRIPTION
This pull request makes a minor update to the user-facing hint in the `TranslateMenuProvider` component. The change clarifies the message shown when translation is not available, making it more specific and helpful for users.